### PR TITLE
Implemented programmatic content script injection

### DIFF
--- a/content.js
+++ b/content.js
@@ -12,14 +12,16 @@ var bath = apt_info.match(/\s([0-9]+)\sbath/)[1];
 var bed = apt_info.match(/\s([0-9]+)\sbed/)[1];
 var sqft = apt_info.match(/\s([0-9]+)\ssqft/)[1];
 
-var rental_price = document.getElementsByClassName("main-row home-summary-row")[0];
+var rental_price = document.getElementsByClassName("main-row home-summary-row")[0].textContent;
 
-rental["address"] = address;
+rental["address"] = address.trim();
 rental["bed"] = bed;
 rental["bath"] = bath;
 rental["sqft"] = sqft;
-rental["rental_price"] = rental_price;
+rental["rental_price"] = rental_price.trim();
 
 console.log(rental);
 
 chrome.extension.sendMessage(rental);
+
+window.close();

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function processBookmark(bookmarks, folder_name) {
                     alert("Sorry, the folder you selected appears to not contain any bookmarks.");
                     return true;
                 }
-                parseBookmarks(bookmark.children);
+                openBookmarksForParsing(bookmark.children);
                 return true;
             }
         }
@@ -31,24 +31,19 @@ var processBookmarks = function (folder_name) {
     };
 };
 
-function parseBookmarks(children) {
-    var text = "";
-    for (var j = 0; j < children.length; j++) {
-        var node = children[j];
-        text += node.title + "  :  " + node.url + "\n";
-        var xhr = new XMLHttpRequest();
-        xhr.onreadystatechange = function () {
-            if (this.readyState == 4 && this.status == 200) {
-                alert(xhr.responseText);
-            }
-        };
-        xhr.open("GET", node.url, true);
-        xhr.send();
+function openBookmarksForParsing(bookmarksToOpen) {
+    for (var j = 0; j < bookmarksToOpen.length; j++) {
+        var bookmark = bookmarksToOpen[j];
+        var createProperties = {"active": false, "url": bookmark.url};
+        chrome.tabs.create(createProperties, function (tab) {
+            var details = {"file": "content.js"};
+            chrome.tabs.executeScript(tab.id, details);
+        });
     }
-    alert(text);
 }
 
 document.addEventListener("DOMContentLoaded", function () {
+
     document.getElementById("submit-button").addEventListener("click", function () {
         var folder_name = document.getElementById("folder-name").value;
         chrome.bookmarks.getTree(processBookmarks(folder_name));

--- a/manifest.json
+++ b/manifest.json
@@ -7,12 +7,6 @@
         "persistent": false,
         "scripts": ["background.js"]
     },
-    "content_scripts": [
-        {
-            "matches": ["*://www.zillow.com/*"],
-            "js": ["content.js"]
-        }
-    ],
     "permissions": ["bookmarks", "*://www.zillow.com/*"],
     "icons": {
         "20": "zillow_thumbnail.png"


### PR DESCRIPTION
My extension's scripts are now only embedded in zillow pages when a user selects to open them from their bookmarks on the extension's main page, instead of all pages always, indiscriminantly.  Also, some small code cleanup.